### PR TITLE
support chrome dev/beta on macos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/js-debug-browsers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/js-debug-browsers",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "execa": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/js-debug-browsers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Browser launch and discovery logic used in VS Code's JavaScript Debugger",
   "main": "dist/index.js",
   "scripts": {

--- a/src/darwinChrome.ts
+++ b/src/darwinChrome.ts
@@ -32,17 +32,19 @@ export class DarwinChromeBrowserFinder extends DarwinFinderBase {
     },
   ];
 
-  /**
-   * @override
-   */
-  public async findAll() {
-    const suffixes = ['/Contents/MacOS/Google Chrome Canary', '/Contents/MacOS/Google Chrome'];
+  protected override async findAllInner() {
+    const suffixes = [
+      '/Contents/MacOS/Google Chrome Canary',
+      '/Contents/MacOS/Google Chrome Beta',
+      '/Contents/MacOS/Google Chrome Dev',
+      '/Contents/MacOS/Google Chrome',
+    ];
     const defaultPaths = [
       '/Applications/Google Chrome.app',
       '/Applications/Google Chrome Canary.app',
     ];
     const installations = await this.findLaunchRegisteredApps(
-      'google chrome\\( canary\\)\\?.app',
+      'google chrome[A-Za-z() ]*.app',
       defaultPaths,
       suffixes,
     );
@@ -59,6 +61,16 @@ export class DarwinChromeBrowserFinder extends DarwinFinderBase {
           name: 'Chrome Canary.app',
           weight: 1,
           quality: Quality.Canary,
+        },
+        {
+          name: 'Chrome Beta.app',
+          weight: 2,
+          quality: Quality.Beta,
+        },
+        {
+          name: 'Chrome Dev.app',
+          weight: 3,
+          quality: Quality.Dev,
         },
       ]),
     );

--- a/src/darwinEdge.ts
+++ b/src/darwinEdge.ts
@@ -32,10 +32,7 @@ export class DarwinEdgeBrowserFinder extends DarwinFinderBase {
     },
   ];
 
-  /**
-   * @override
-   */
-  public async findAll() {
+  protected override async findAllInner() {
     const suffixes = [
       '/Contents/MacOS/Microsoft Edge Canary',
       '/Contents/MacOS/Microsoft Edge Beta',


### PR DESCRIPTION
For https://github.com/microsoft/vscode-js-debug/issues/1489

Also, cache lsregister lookup since it's slow and we do it twice.