### PR TITLE
Add Firefox detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/js-debug-browsers",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Browser launch and discovery logic used in VS Code's JavaScript Debugger",
   "main": "dist/index.js",
   "scripts": {

--- a/src/darwinEdge.ts
+++ b/src/darwinEdge.ts
@@ -7,7 +7,7 @@ import { Quality } from './index';
 import { DarwinFinderBase } from './darwinFinderBase';
 
 /**
- * Finds the Edege browser on OS X.
+ * Finds the Edge browser on OS X.
  */
 export class DarwinEdgeBrowserFinder extends DarwinFinderBase {
   /**

--- a/src/darwinFinderBase.ts
+++ b/src/darwinFinderBase.ts
@@ -29,9 +29,9 @@ export abstract class DarwinFinderBase implements IBrowserFinder {
   private foundAll: Promise<IExecutable[]> | undefined;
 
   constructor(
-    protected readonly env: NodeJS.ProcessEnv,
-    private readonly fs: typeof fsPromises,
-    private readonly execa: typeof _execa,
+    protected readonly env: NodeJS.ProcessEnv = process.env,
+    private readonly fs: typeof fsPromises = fsPromises,
+    private readonly execa: typeof _execa = execa,
   ) {}
 
   /**

--- a/src/darwinFirefox.test.ts
+++ b/src/darwinFirefox.test.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { stub } from 'sinon';
+import { expect } from 'chai';
+import { Quality } from '.';
+import { DarwinFirefoxBrowserFinder } from './darwinFirefox';
+
+describe('darwin: firefox', () => {
+  const lsreturn = [
+    '/Applications/Firefox.app',
+    ' /Applications/Firefox Developer Edition.app',
+    ' /Applications/Firefox Nightly.app',
+  ];
+
+  const setup = (options: { lsreturn: string[]; pathsThatExist: string[] }) => {
+    const execa = {
+      command: stub().resolves({ stdout: options.lsreturn.join('\n') }),
+    };
+
+    const fs = {
+      access: (path: string) => {
+        if (!options.pathsThatExist.includes(path)) {
+          throw new Error('no access here!');
+        }
+      },
+    };
+
+    const finder = new DarwinFirefoxBrowserFinder(
+      { FIREFOX_PATH: '/custom/path' },
+      fs as any,
+      execa as any,
+    );
+
+    return finder;
+  };
+
+  it('does not return when paths dont exist', async () => {
+    expect(
+      await setup({
+        lsreturn,
+        pathsThatExist: [],
+      }).findAll(),
+    ).to.be.empty;
+  });
+
+  it('returns and orders correctly', async () => {
+    expect(
+      await setup({
+        lsreturn,
+        pathsThatExist: [
+          '/custom/path/Contents/MacOS/firefox',
+          '/Applications/Firefox.app/Contents/MacOS/firefox',
+          '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
+          '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+        ],
+      }).findAll(),
+    ).to.deep.equal([
+      {
+        path: '/custom/path/Contents/MacOS/firefox',
+        quality: Quality.Custom,
+      },
+      {
+        path: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+        quality: Quality.Nightly,
+      },
+      {
+        path: '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
+        quality: Quality.Dev,
+      },
+      {
+        path: '/Applications/Firefox.app/Contents/MacOS/firefox',
+        quality: Quality.Stable,
+      },
+    ]);
+  });
+
+  it('finds well-known paths', async () => {
+    const s = setup({
+      lsreturn,
+      pathsThatExist: [
+        '/custom/path/Contents/MacOS/firefox',
+        '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
+        '/Applications/Firefox.app/Contents/MacOS/firefox',
+      ],
+    });
+
+    let calls = 0;
+    expect(
+      await s.findWhere((exe) => {
+        calls++;
+        return exe.quality === Quality.Stable;
+      }),
+    ).to.deep.equal({
+      path: '/Applications/Firefox.app/Contents/MacOS/firefox',
+      quality: Quality.Stable,
+    });
+
+    expect(calls).to.equal(1);
+
+    expect(
+      await s.findWhere((exe) => {
+        calls++;
+        return exe.quality === Quality.Canary;
+      }),
+    ).to.be.undefined;
+  });
+});

--- a/src/darwinFirefox.test.ts
+++ b/src/darwinFirefox.test.ts
@@ -63,7 +63,7 @@ describe('darwin: firefox', () => {
       },
       {
         path: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
-        quality: Quality.Nightly,
+        quality: Quality.Canary,
       },
       {
         path: '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',

--- a/src/darwinFirefox.test.ts
+++ b/src/darwinFirefox.test.ts
@@ -62,12 +62,12 @@ describe('darwin: firefox', () => {
         quality: Quality.Custom,
       },
       {
-        path: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
-        quality: Quality.Canary,
-      },
-      {
         path: '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
         quality: Quality.Dev,
+      },
+      {
+        path: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+        quality: Quality.Canary,
       },
       {
         path: '/Applications/Firefox.app/Contents/MacOS/firefox',

--- a/src/darwinFirefox.ts
+++ b/src/darwinFirefox.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { sort } from './util';
+import { Quality } from './index';
+import { DarwinFinderBase } from './darwinFinderBase';
+
+/**
+ * Finds the Edege browser on OS X.
+ */
+export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
+  /**
+   * @override
+   */
+  protected wellKnownPaths = [
+    {
+      path: '/Applications/Firefox.app/Contents/MacOS/firefox',
+      quality: Quality.Stable,
+    },
+    {
+      path: '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
+      quality: Quality.Dev,
+    },
+    {
+      path: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+      quality: Quality.Nightly,
+    },
+  ];
+
+  protected override async findAllInner() {
+    const suffixes = [
+      '/Contents/MacOS/firefox',
+    ];
+
+    const defaultPaths = ['/Applications/Firefox.app'];
+    const installations = await this.findLaunchRegisteredApps(
+      'Firefox[A-Za-z ]*.app',
+      defaultPaths,
+      suffixes,
+    );
+
+    return sort(
+      installations,
+      this.createPriorities([
+        {
+          name: 'Firefox.app',
+          weight: 0,
+          quality: Quality.Stable,
+        },
+        {
+          name: 'Firefox Developer Edition.app',
+          weight: 1,
+          quality: Quality.Dev,
+        },
+        {
+          name: 'Firefox Nightly.app',
+          weight: 2,
+          quality: Quality.Nightly,
+        }
+      ]),
+    );
+  }
+
+  protected getPreferredPath() {
+    return this.env.FIREFOX_PATH;
+  }
+}

--- a/src/darwinFirefox.ts
+++ b/src/darwinFirefox.ts
@@ -24,7 +24,7 @@ export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
     },
     {
       path: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
-      quality: Quality.Nightly,
+      quality: Quality.Canary,
     },
   ];
 
@@ -56,7 +56,7 @@ export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
         {
           name: 'Firefox Nightly.app',
           weight: 2,
-          quality: Quality.Nightly,
+          quality: Quality.Canary,
         }
       ]),
     );

--- a/src/darwinFirefox.ts
+++ b/src/darwinFirefox.ts
@@ -47,14 +47,14 @@ export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
           quality: Quality.Stable,
         },
         {
-          name: 'Firefox Developer Edition.app',
+          name: 'Firefox Nightly.app',
           weight: 1,
-          quality: Quality.Dev,
+          quality: Quality.Canary,
         },
         {
-          name: 'Firefox Nightly.app',
+          name: 'Firefox Developer Edition.app',
           weight: 2,
-          quality: Quality.Canary,
+          quality: Quality.Dev,
         },
       ]),
     );

--- a/src/darwinFirefox.ts
+++ b/src/darwinFirefox.ts
@@ -7,7 +7,7 @@ import { Quality } from './index';
 import { DarwinFinderBase } from './darwinFinderBase';
 
 /**
- * Finds the Edege browser on OS X.
+ * Finds the Firefox browser on OS X.
  */
 export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
   /**

--- a/src/darwinFirefox.ts
+++ b/src/darwinFirefox.ts
@@ -29,9 +29,7 @@ export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
   ];
 
   protected override async findAllInner() {
-    const suffixes = [
-      '/Contents/MacOS/firefox',
-    ];
+    const suffixes = ['/Contents/MacOS/firefox'];
 
     const defaultPaths = ['/Applications/Firefox.app'];
     const installations = await this.findLaunchRegisteredApps(
@@ -57,7 +55,7 @@ export class DarwinFirefoxBrowserFinder extends DarwinFinderBase {
           name: 'Firefox Nightly.app',
           weight: 2,
           quality: Quality.Canary,
-        }
+        },
       ]),
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,5 +98,5 @@ export const FirefoxBrowserFinder: BrowserFinderCtor =
   process.platform === 'win32'
     ? WindowsFirefoxBrowserFinder
     : process.platform === 'darwin'
-      ? DarwinFirefoxBrowserFinder
-      : LinuxFirefoxBrowserFinder;
+    ? DarwinFirefoxBrowserFinder
+    : LinuxFirefoxBrowserFinder;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ export const enum Quality {
   Stable = 'stable',
   Beta = 'beta',
   Dev = 'dev',
-  Nightly = 'nightly',
   Custom = 'custom', // environment-configured quality
 }
 
@@ -32,7 +31,6 @@ const qualities: { [K in Quality]: null } = {
   [Quality.Stable]: null,
   [Quality.Beta]: null,
   [Quality.Dev]: null,
-  [Quality.Nightly]: null,
   [Quality.Custom]: null,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,13 @@ import execa from 'execa';
 import { promises as fs } from 'fs';
 import { DarwinChromeBrowserFinder } from './darwinChrome';
 import { DarwinEdgeBrowserFinder } from './darwinEdge';
+import { DarwinFirefoxBrowserFinder } from './darwinFirefox';
 import { LinuxChromeBrowserFinder } from './linuxChrome';
 import { LinuxEdgeBrowserFinder } from './linuxEdge';
+import { LinuxFirefoxBrowserFinder } from './linuxFirefox';
 import { WindowsChromeBrowserFinder } from './windowsChrome';
 import { WindowsEdgeBrowserFinder } from './windowsEdge';
+import { WindowsFirefoxBrowserFinder } from './windowsFirefox';
 
 /**
  * Quality (i.e. release channel) of discovered binary.
@@ -89,3 +92,13 @@ export const EdgeBrowserFinder: BrowserFinderCtor =
     : process.platform === 'darwin'
     ? DarwinEdgeBrowserFinder
     : LinuxEdgeBrowserFinder;
+
+/**
+ * Firefox finder class for the current platform.
+ */
+export const FirefoxBrowserFinder: BrowserFinderCtor =
+  process.platform === 'win32'
+    ? WindowsFirefoxBrowserFinder
+    : process.platform === 'darwin'
+      ? DarwinFirefoxBrowserFinder
+      : LinuxFirefoxBrowserFinder;

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,9 +66,9 @@ export interface IBrowserFinder {
 }
 
 export type BrowserFinderCtor = new (
-  env: NodeJS.ProcessEnv,
-  _fs: typeof fs,
-  _execa: typeof execa,
+  env?: NodeJS.ProcessEnv,
+  _fs?: typeof fs,
+  _execa?: typeof execa,
 ) => IBrowserFinder;
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export const enum Quality {
   Stable = 'stable',
   Beta = 'beta',
   Dev = 'dev',
+  Nightly = 'nightly',
   Custom = 'custom', // environment-configured quality
 }
 
@@ -28,6 +29,7 @@ const qualities: { [K in Quality]: null } = {
   [Quality.Stable]: null,
   [Quality.Beta]: null,
   [Quality.Dev]: null,
+  [Quality.Nightly]: null,
   [Quality.Custom]: null,
 };
 

--- a/src/linuxChrome.ts
+++ b/src/linuxChrome.ts
@@ -16,8 +16,8 @@ const newLineRegex = /\r?\n/;
  */
 export class LinuxChromeBrowserFinder implements IBrowserFinder {
   constructor(
-    protected readonly env: NodeJS.ProcessEnv,
-    protected readonly fs: typeof fsPromises,
+    protected readonly env: NodeJS.ProcessEnv = process.env,
+    protected readonly fs: typeof fsPromises = fsPromises,
   ) {}
 
   protected readonly pathEnvironmentVar: string = 'CHROME_PATH';

--- a/src/linuxFirefox.ts
+++ b/src/linuxFirefox.ts
@@ -5,7 +5,7 @@
 import { Quality } from '.';
 import { LinuxChromeBrowserFinder } from './linuxChrome';
 
-export class LinuxEdgeBrowserFinder extends LinuxChromeBrowserFinder {
+export class LinuxFirefoxBrowserFinder extends LinuxChromeBrowserFinder {
   protected override pathEnvironmentVar = 'FIREFOX_PATH';
 
   protected override executablesOnPath = [

--- a/src/linuxFirefox.ts
+++ b/src/linuxFirefox.ts
@@ -11,6 +11,7 @@ export class LinuxEdgeBrowserFinder extends LinuxChromeBrowserFinder {
   protected override executablesOnPath = [
     'firefox-trunk',
     'firefox-nightly',
+    'firefox-aurora',
     'firefox-dev',
     'firefox-developer',
     'firefox',
@@ -19,6 +20,7 @@ export class LinuxEdgeBrowserFinder extends LinuxChromeBrowserFinder {
   protected override priorities = [
     { regex: /firefox\-trunk'$/, weight: 51, quality: Quality.Nightly },
     { regex: /firefox\-nightly'$/, weight: 51, quality: Quality.Nightly },
+    { regex: /firefox\-aurora$/, weight: 50, quality: Quality.Dev },
     { regex: /firefox\-dev$/, weight: 50, quality: Quality.Dev },
     { regex: /firefox\-developer$/, weight: 50, quality: Quality.Dev },
     { regex: /firefox$/, weight: 49, quality: Quality.Stable },

--- a/src/linuxFirefox.ts
+++ b/src/linuxFirefox.ts
@@ -9,20 +9,20 @@ export class LinuxFirefoxBrowserFinder extends LinuxChromeBrowserFinder {
   protected override pathEnvironmentVar = 'FIREFOX_PATH';
 
   protected override executablesOnPath = [
-    'firefox-trunk',
-    'firefox-nightly',
     'firefox-aurora',
     'firefox-dev',
     'firefox-developer',
+    'firefox-trunk',
+    'firefox-nightly',
     'firefox',
   ];
 
   protected override priorities = [
-    { regex: /firefox\-trunk'$/, weight: 51, quality: Quality.Canary },
-    { regex: /firefox\-nightly'$/, weight: 51, quality: Quality.Canary },
-    { regex: /firefox\-aurora$/, weight: 50, quality: Quality.Dev },
-    { regex: /firefox\-dev$/, weight: 50, quality: Quality.Dev },
-    { regex: /firefox\-developer$/, weight: 50, quality: Quality.Dev },
+    { regex: /firefox\-aurora$/, weight: 51, quality: Quality.Dev },
+    { regex: /firefox\-dev$/, weight: 51, quality: Quality.Dev },
+    { regex: /firefox\-developer$/, weight: 51, quality: Quality.Dev },
+    { regex: /firefox\-trunk'$/, weight: 50, quality: Quality.Canary },
+    { regex: /firefox\-nightly'$/, weight: 50, quality: Quality.Canary },
     { regex: /firefox$/, weight: 49, quality: Quality.Stable },
   ];
 }

--- a/src/linuxFirefox.ts
+++ b/src/linuxFirefox.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Quality } from '.';
+import { LinuxChromeBrowserFinder } from './linuxChrome';
+
+export class LinuxEdgeBrowserFinder extends LinuxChromeBrowserFinder {
+  protected override pathEnvironmentVar = 'FIREFOX_PATH';
+
+  protected override executablesOnPath = [
+    'firefox-trunk',
+    'firefox-nightly',
+    'firefox-dev',
+    'firefox-developer',
+    'firefox',
+  ];
+
+  protected override priorities = [
+    { regex: /firefox\-trunk'$/, weight: 51, quality: Quality.Nightly },
+    { regex: /firefox\-nightly'$/, weight: 51, quality: Quality.Nightly },
+    { regex: /firefox\-dev$/, weight: 50, quality: Quality.Dev },
+    { regex: /firefox\-developer$/, weight: 50, quality: Quality.Dev },
+    { regex: /firefox$/, weight: 49, quality: Quality.Stable },
+  ];
+}

--- a/src/linuxFirefox.ts
+++ b/src/linuxFirefox.ts
@@ -18,8 +18,8 @@ export class LinuxFirefoxBrowserFinder extends LinuxChromeBrowserFinder {
   ];
 
   protected override priorities = [
-    { regex: /firefox\-trunk'$/, weight: 51, quality: Quality.Nightly },
-    { regex: /firefox\-nightly'$/, weight: 51, quality: Quality.Nightly },
+    { regex: /firefox\-trunk'$/, weight: 51, quality: Quality.Canary },
+    { regex: /firefox\-nightly'$/, weight: 51, quality: Quality.Canary },
     { regex: /firefox\-aurora$/, weight: 50, quality: Quality.Dev },
     { regex: /firefox\-dev$/, weight: 50, quality: Quality.Dev },
     { regex: /firefox\-developer$/, weight: 50, quality: Quality.Dev },

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,6 +51,18 @@ export async function preferredChromePath(
 }
 
 /**
+ * Gets the configured Firefox path, if any.
+ */
+export async function preferredFirefoxPath(
+  fs: typeof fsPromises,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  if (await canAccess(fs, env.FIREFOX_PATH)) {
+    return env.FIREFOX_PATH;
+  }
+}
+
+/**
  * Gets the configured Edge path, if any.
  */
 export async function preferredEdgePath(

--- a/src/windowsChrome.ts
+++ b/src/windowsChrome.ts
@@ -11,7 +11,10 @@ import { promises as fsPromises } from 'fs';
  * Finds the Chrome browser on Windows.
  */
 export class WindowsChromeBrowserFinder implements IBrowserFinder {
-  constructor(private readonly env: NodeJS.ProcessEnv, private readonly fs: typeof fsPromises) {}
+  constructor(
+    private readonly env: NodeJS.ProcessEnv = process.env,
+    private readonly fs: typeof fsPromises = fsPromises,
+  ) {}
 
   public async findWhere(predicate: (exe: IExecutable) => boolean) {
     return (await this.findAll()).find(predicate);

--- a/src/windowsEdge.ts
+++ b/src/windowsEdge.ts
@@ -11,7 +11,10 @@ import { preferredEdgePath, findWindowsCandidates } from './util';
  * Finds the Chrome browser on Windows.
  */
 export class WindowsEdgeBrowserFinder implements IBrowserFinder {
-  constructor(private readonly env: NodeJS.ProcessEnv, private readonly fs: typeof fsPromises) {}
+  constructor(
+    private readonly env: NodeJS.ProcessEnv = process.env,
+    private readonly fs: typeof fsPromises = fsPromises,
+  ) {}
 
   public async findWhere(predicate: (exe: IExecutable) => boolean) {
     return (await this.findAll()).find(predicate);

--- a/src/windowsFirefox.test.ts
+++ b/src/windowsFirefox.test.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { Quality } from '.';
+import { WindowsFirefoxBrowserFinder } from './windowsFirefox';
+
+describe('windows: firefox', () => {
+  const test = (pathsThatExist: string[]) => {
+    const fs = {
+      access: (path: string) => {
+        if (!pathsThatExist.includes(path)) {
+          throw new Error('no access here!');
+        }
+      },
+    };
+
+    return new WindowsFirefoxBrowserFinder(
+      {
+        LOCALAPPDATA: '%APPDATA%',
+        PROGRAMFILES: '%PROGRAMFILES%',
+        'PROGRAMFILES(X86)': '%PROGRAMFILES(X86)%',
+        FIREFOX_PATH: 'C:\\custom\\path\\firefox.exe',
+      },
+      fs as any,
+    ).findAll();
+  };
+
+  it('does not return when paths dont exist', async () => {
+    expect(await test([])).to.be.empty;
+  });
+
+  it('returns and orders correctly', async () => {
+    expect(
+      await test([
+        'C:\\custom\\path\\firefox.exe',
+        '%PROGRAMFILES%\\Firefox Developer Edition\\firefox.exe',
+        '%PROGRAMFILES%\\Firefox Nightly\\firefox.exe',
+        '%APPDATA%\\Mozilla Firefox\\firefox.exe',
+      ]),
+    ).to.deep.equal([
+      {
+        path: 'C:\\custom\\path\\firefox.exe',
+        quality: Quality.Custom,
+      },
+      {
+        path: '%APPDATA%\\Mozilla Firefox\\firefox.exe',
+        quality: Quality.Stable,
+      },
+      {
+        path: '%PROGRAMFILES%\\Firefox Developer Edition\\firefox.exe',
+        quality: Quality.Dev,
+      },
+      {
+        path: '%PROGRAMFILES%\\Firefox Nightly\\firefox.exe',
+        quality: Quality.Nightly,
+      },
+    ]);
+  });
+});

--- a/src/windowsFirefox.test.ts
+++ b/src/windowsFirefox.test.ts
@@ -54,7 +54,7 @@ describe('windows: firefox', () => {
       },
       {
         path: '%PROGRAMFILES%\\Firefox Nightly\\firefox.exe',
-        quality: Quality.Nightly,
+        quality: Quality.Canary,
       },
     ]);
   });

--- a/src/windowsFirefox.ts
+++ b/src/windowsFirefox.ts
@@ -26,7 +26,7 @@ export class WindowsFirefoxBrowserFinder implements IBrowserFinder {
             },
             {
                 name: `${sep}Firefox Nightly${sep}firefox.exe`,
-                type: Quality.Nightly,
+              type: Quality.Canary,
             },
             {
                 name: `${sep}Mozilla Firefox${sep}firefox.exe`,

--- a/src/windowsFirefox.ts
+++ b/src/windowsFirefox.ts
@@ -11,35 +11,35 @@ import { promises as fsPromises } from 'fs';
  * Finds the Chrome browser on Windows.
  */
 export class WindowsFirefoxBrowserFinder implements IBrowserFinder {
-    constructor(private readonly env: NodeJS.ProcessEnv, private readonly fs: typeof fsPromises) { }
+  constructor(private readonly env: NodeJS.ProcessEnv, private readonly fs: typeof fsPromises) {}
 
-    public async findWhere(predicate: (exe: IExecutable) => boolean) {
-        return (await this.findAll()).find(predicate);
+  public async findWhere(predicate: (exe: IExecutable) => boolean) {
+    return (await this.findAll()).find(predicate);
+  }
+
+  public async findAll() {
+    const sep = win32.sep;
+    const suffixes = [
+      {
+        name: `${sep}Firefox Developer Edition${sep}firefox.exe`,
+        type: Quality.Dev,
+      },
+      {
+        name: `${sep}Firefox Nightly${sep}firefox.exe`,
+        type: Quality.Canary,
+      },
+      {
+        name: `${sep}Mozilla Firefox${sep}firefox.exe`,
+        type: Quality.Stable,
+      },
+    ];
+
+    const installations = await findWindowsCandidates(this.env, this.fs, suffixes);
+    const customFirefoxPath = await preferredFirefoxPath(this.fs, this.env);
+    if (customFirefoxPath) {
+      installations.unshift({ path: customFirefoxPath, quality: Quality.Custom });
     }
 
-    public async findAll() {
-        const sep = win32.sep;
-        const suffixes = [
-            {
-                name: `${sep}Firefox Developer Edition${sep}firefox.exe`,
-                type: Quality.Dev,
-            },
-            {
-                name: `${sep}Firefox Nightly${sep}firefox.exe`,
-              type: Quality.Canary,
-            },
-            {
-                name: `${sep}Mozilla Firefox${sep}firefox.exe`,
-                type: Quality.Stable,
-            },
-        ];
-
-        const installations = await findWindowsCandidates(this.env, this.fs, suffixes);
-        const customFirefoxPath = await preferredFirefoxPath(this.fs, this.env);
-        if (customFirefoxPath) {
-            installations.unshift({ path: customFirefoxPath, quality: Quality.Custom });
-        }
-
-        return installations;
-    }
+    return installations;
+  }
 }

--- a/src/windowsFirefox.ts
+++ b/src/windowsFirefox.ts
@@ -29,11 +29,7 @@ export class WindowsFirefoxBrowserFinder implements IBrowserFinder {
                 type: Quality.Nightly,
             },
             {
-                name: `${sep}Mozilla${sep}Firefox${sep}firefox.exe`,
-                type: Quality.Beta,
-            },
-            {
-                name: `${sep}Mozilla${sep}Firefox${sep}firefox.exe`,
+                name: `${sep}Mozilla Firefox${sep}firefox.exe`,
                 type: Quality.Stable,
             },
         ];

--- a/src/windowsFirefox.ts
+++ b/src/windowsFirefox.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Quality, IBrowserFinder, IExecutable } from './index';
+import { win32 } from 'path';
+import { findWindowsCandidates, preferredFirefoxPath } from './util';
+import { promises as fsPromises } from 'fs';
+
+/**
+ * Finds the Chrome browser on Windows.
+ */
+export class WindowsFirefoxBrowserFinder implements IBrowserFinder {
+    constructor(private readonly env: NodeJS.ProcessEnv, private readonly fs: typeof fsPromises) { }
+
+    public async findWhere(predicate: (exe: IExecutable) => boolean) {
+        return (await this.findAll()).find(predicate);
+    }
+
+    public async findAll() {
+        const sep = win32.sep;
+        const suffixes = [
+            {
+                name: `${sep}Firefox Developer Edition${sep}firefox.exe`,
+                type: Quality.Dev,
+            },
+            {
+                name: `${sep}Firefox Nightly${sep}firefox.exe`,
+                type: Quality.Nightly,
+            },
+            {
+                name: `${sep}Mozilla${sep}Firefox${sep}firefox.exe`,
+                type: Quality.Beta,
+            },
+            {
+                name: `${sep}Mozilla${sep}Firefox${sep}firefox.exe`,
+                type: Quality.Stable,
+            },
+        ];
+
+        const installations = await findWindowsCandidates(this.env, this.fs, suffixes);
+        const customFirefoxPath = await preferredFirefoxPath(this.fs, this.env);
+        if (customFirefoxPath) {
+            installations.unshift({ path: customFirefoxPath, quality: Quality.Custom });
+        }
+
+        return installations;
+    }
+}

--- a/src/windowsFirefox.ts
+++ b/src/windowsFirefox.ts
@@ -11,7 +11,10 @@ import { promises as fsPromises } from 'fs';
  * Finds the Chrome browser on Windows.
  */
 export class WindowsFirefoxBrowserFinder implements IBrowserFinder {
-  constructor(private readonly env: NodeJS.ProcessEnv, private readonly fs: typeof fsPromises) {}
+  constructor(
+    private readonly env: NodeJS.ProcessEnv = process.env,
+    private readonly fs: typeof fsPromises = fsPromises,
+  ) {}
 
   public async findWhere(predicate: (exe: IExecutable) => boolean) {
     return (await this.findAll()).find(predicate);


### PR DESCRIPTION
Use common paths to find Firefox on supported platforms. For the most part, I just used common paths to guess where the installation may be.